### PR TITLE
Fixed brokenness in 7.2.1 (alternative fix)

### DIFF
--- a/Database/MongoDB/Query.hs
+++ b/Database/MongoDB/Query.hs
@@ -42,7 +42,7 @@ import Prelude as X hiding (lookup)
 import Data.UString as U (UString, dropWhile, any, tail)
 import Data.Bson (Document, at, valueAt, lookup, look, Field(..), (=:), (=?), Label, Value(String,Doc), Javascript, genObjectId)
 import Database.MongoDB.Internal.Protocol (Pipe, Notice(..), Request(GetMore), Reply(..), QueryOption(..), ResponseFlag(..), InsertOption(..), UpdateOption(..), DeleteOption(..), CursorId, FullCollection, Username, Password, pwKey)
-import qualified Database.MongoDB.Internal.Protocol as P (send, call, Request(Query))
+import qualified Database.MongoDB.Internal.Protocol as P (send, call, Request(Query, qOptions, qFullCollection, qSkip, qBatchSize, qSelector, qProjector))
 import Database.MongoDB.Internal.Util (MonadIO', loop, liftIOE, true1, (<.>))
 import Control.Monad.MVar
 import Control.Monad.Error


### PR DESCRIPTION
This is the same issue as reported by mkscrg, but my fix is to import all the field labels explicitly, which causes the code to work as expected.  Although this fix is a smaller change than mkscrg's, it may be better to go with his, since record wildcards seem fragile and/or dangerous (at least in 7.2.1).
