### PR TITLE
Improve the parsing of HostPorts received from MongoDB to work properly with with IPv6 addresses

### DIFF
--- a/tests/TestReadHostPort.hs
+++ b/tests/TestReadHostPort.hs
@@ -1,0 +1,24 @@
+import Database.MongoDB.Connection
+import System.Exit
+import Control.Monad
+
+testList = [
+  ("Simple host", readHostPort "host" == Host "host" (PortNumber 27017)),
+  ("Simple host with port", readHostPort "host:123" == Host "host" (PortNumber 123)),
+  ("Pathological ::1:1234 case", readHostPort "::1:1234" == Host "::1" (PortNumber 1234)),
+  ("Full IPv6 with port", readHostPort "1:2:3:4:5:6:7:8:1234" == Host "1:2:3:4:5:6:7:8" (PortNumber 1234)),
+  ("Full IPv6 without port", readHostPort "1:2:3:4:5:6:7:8" == Host "1:2:3:4:5:6:7:8" (PortNumber 27017)),
+  ("Partial IPv6 with port", readHostPort "1:2:3::4:12" == Host "1:2:3::4" (PortNumber 12)),
+  ("Partial IPv6 with hex at end", readHostPort "1:2:3::4:a" == Host "1:2:3::4:a" (PortNumber 27017))
+           ]
+main =
+  let
+    failedTests = filter (not . snd) testList
+  in
+   if null failedTests then
+     putStrLn "All tests passed"
+   else
+     do
+       putStrLn "The following tests failed:"
+       forM_ failedTests $ \(descr, _) -> putStrLn $ "  * " ++ descr
+       exitWith (ExitFailure 1)


### PR DESCRIPTION
Improve the parsing of HostPorts received from MongoDB to work properly with with IPv6 addresses.

MongoDB's syntax is ambiguous and complex to deal with respect to IPv6 addresses, because the :
character is used to delimit both the parts of the IPv6 address, so the parser needs to be quite
complex.

This code will parse ambiguous examples like ::1:1234 as host ::1, port 1234, matching the approach
taken in MongoDB server codebase. If only one interpretation is possible, it will take that
interpretation. For example ::1:a is parsed as having no port specifier (since a is not a valid
decimal digit).

Also add a test program that tests the code with a number of cases.
