### PR TITLE
Fix example errors

### DIFF
--- a/doc/Example.hs
+++ b/doc/Example.hs
@@ -1,11 +1,14 @@
-{-# LANGUAGE OverloadedStrings, ExtendedDefaultRules #-}
-
 import Database.MongoDB
 import Control.Monad.Trans (liftIO)
+import Data.Text (pack)
+import Data.Bson
+
+(==:) :: (Val a) => String -> a -> Field
+a ==: b = pack a =: b
 
 main = do
     pipe <- runIOE $ connect (host "127.0.0.1")
-    e <- access pipe master "baseball" run
+    e <- access pipe master (pack "baseball") run
     close pipe
     print e
 
@@ -16,18 +19,18 @@ run = do
     nationalLeagueTeams >>= printDocs "National League Teams"
     newYorkTeams >>= printDocs "New York Teams"
 
-clearTeams = delete (select [] "team")
+clearTeams = delete (select [] (pack "team"))
 
-insertTeams = insertMany "team" [
-    ["name" =: "Yankees", "home" =: ["city" =: "New York", "state" =: "NY"], "league" =: "American"],
-    ["name" =: "Mets", "home" =: ["city" =: "New York", "state" =: "NY"], "league" =: "National"],
-    ["name" =: "Phillies", "home" =: ["city" =: "Philadelphia", "state" =: "PA"], "league" =: "National"],
-    ["name" =: "Red Sox", "home" =: ["city" =: "Boston", "state" =: "MA"], "league" =: "American"] ]
+insertTeams = insertMany (pack "team") [
+    ["name" ==: "Yankees", "home" ==: ["city" ==: "New York", "state" ==: "NY"], "league" ==: "American"],
+    ["name" ==: "Mets", "home" ==: ["city" ==: "New York", "state" ==: "NY"], "league" ==: "National"],
+    ["name" ==: "Phillies", "home" ==: ["city" ==: "Philadelphia", "state" ==: "PA"], "league" ==: "National"],
+    ["name" ==: "Red Sox", "home" ==: ["city" ==: "Boston", "state" ==: "MA"], "league" ==: "American"] ]
 
-allTeams = rest =<< find (select [] "team") {sort = ["home.city" =: 1]}
+allTeams = rest =<< find (select [] $ pack "team") {sort = ["home.city" ==: (1 :: Int)]}
 
-nationalLeagueTeams = rest =<< find (select ["league" =: "National"] "team")
+nationalLeagueTeams = rest =<< find (select ["league" ==: "National"] $ pack "team")
 
-newYorkTeams = rest =<< find (select ["home.state" =: "NY"] "team") {project = ["name" =: 1, "league" =: 1]}
+newYorkTeams = rest =<< find (select ["home.state" ==: "NY"] $ pack "team") {project = ["name" ==: (1 :: Int), "league" ==: (1 :: Int)]}
 
-printDocs title docs = liftIO $ putStrLn title >> mapM_ (print . exclude ["_id"]) docs
+printDocs title docs = liftIO $ putStrLn title >> mapM_ (print . exclude [pack "_id"]) docs


### PR DESCRIPTION
There are compilation errors in `Example.hs` which I assume to be the result of an earlier migration from String to Text. I did a quick fix by converting all strings to `Text` using `pack`, and also declared a function `==:` for convenience. I would suggest accepting this as soon as possible; it looks bad when your own _examples_ don't compile.
